### PR TITLE
Allow Nodes to be Removed without Replacement

### DIFF
--- a/cmd/rotate-eks-instance/main.go
+++ b/cmd/rotate-eks-instance/main.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	name = kingpin.Arg("name", "Internal DNS of EKS instance to rotate").Required().String()
+	name      = kingpin.Arg("name", "Internal DNS of EKS instance to rotate").Required().String()
+	removeNode = kingpin.Flag("remove", "Remove instance, don't provision a replacement").Default("false").Bool()
 )
 
 func init() {
@@ -22,7 +23,7 @@ func main() {
 	kingpin.Parse()
 	ctx, cancel := ctxutil.ContextWithCancelSignals(os.Kill, os.Interrupt)
 	defer cancel()
-	if err := rotator.RotateByInternalDNS(ctx, *name); err != nil {
+	if err := rotator.RotateByInternalDNS(ctx, *name, *removeNode); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/pkg/rotator/aws.go
+++ b/internal/pkg/rotator/aws.go
@@ -94,12 +94,12 @@ func getAutoScalingGroup(client *autoscaling.AutoScaling, name string) (*autosca
 	return out.AutoScalingGroups[0], nil
 }
 
-func DetachInstance(client *autoscaling.AutoScaling, groupId, id string) error {
+func DetachInstance(client *autoscaling.AutoScaling, groupId, id string, removeNode bool) error {
 	log.Printf("Detaching instance '%s' from ASG '%s'...", id, groupId)
 	in := &autoscaling.DetachInstancesInput{
 		InstanceIds:                    aws.StringSlice([]string{id}),
 		AutoScalingGroupName:           aws.String(groupId),
-		ShouldDecrementDesiredCapacity: aws.Bool(false),
+		ShouldDecrementDesiredCapacity: aws.Bool(removeNode),
 	}
 	_, err := client.DetachInstances(in)
 	if err != nil {


### PR DESCRIPTION
Adds flag `--remove` that allows retiring an instance without provisioning a replacement, as is the case for the normal rotation.